### PR TITLE
Fix for bank logo not showing

### DIFF
--- a/classes/WC_Piraeusbank_Gateway.php
+++ b/classes/WC_Piraeusbank_Gateway.php
@@ -84,7 +84,7 @@ class WC_Piraeusbank_Gateway extends WC_Payment_Gateway {
 			add_action( 'admin_notices', [ $this, 'authorize_warning_notice' ] );
 		}
 		if ( $this->pb_render_logo === "yes" ) {
-			$this->icon = apply_filters( 'piraeusbank_icon', plugins_url( 'img/piraeusbank.svg', __FILE__ ) );
+			$this->icon = apply_filters( 'piraeusbank_icon', plugins_url( '../img/piraeusbank.svg', __FILE__ ) );
 		}
 		
 		$this->cardholderNameFunctionality();


### PR DESCRIPTION
As discussed in https://github.com/Enartia/woo-payment-gateway-for-piraeus-bank/issues/1.

This issue was caused by untangling and cleaning up the original code, introducing basic separation of concerns by splitting code into different classes, which caused the wrong relative path to be sent to WooCommerce when registering the payment gateway. This PR fixes the relative path to the logo file.